### PR TITLE
Fix shader include path on case sensitive operating systems

### DIFF
--- a/Assets/Grass.shader
+++ b/Assets/Grass.shader
@@ -24,7 +24,7 @@ Shader "Roystan/Grass"
 
 	CGINCLUDE
 	#include "UnityCG.cginc"
-	#include "Autolight.cginc"
+	#include "AutoLight.cginc"
 	#include "Shaders/CustomTessellation.cginc"
 	
 	struct geometryOutput


### PR DESCRIPTION
This PR fixes a compilation error on Linux.  Thank your for your great work.